### PR TITLE
Add the form attribute to our browser request

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         'z3c.template',
         'zope.authentication',
         'zope.browserpage',
+        'zope.cachedescriptors',
         'zope.component',
         'zope.configuration',
         'zope.dottedname',

--- a/src/nti/app/pyramid_zope/request.py
+++ b/src/nti/app/pyramid_zope/request.py
@@ -118,7 +118,7 @@ class PyramidZopeRequestProxy(SpecificationDecoratorBase):
             rv[name] = v
 
         return rv
-        
+
     @non_overridable
     def get(self, key, default=None):
         """

--- a/src/nti/app/pyramid_zope/request.py
+++ b/src/nti/app/pyramid_zope/request.py
@@ -16,6 +16,8 @@ from zope import interface
 
 from zope.authentication.interfaces import IUnauthenticatedPrincipal
 
+from zope.cachedescriptors.property import Lazy
+
 from zope.i18n.locales import locales
 
 from zope.proxy import non_overridable
@@ -94,6 +96,29 @@ class PyramidZopeRequestProxy(SpecificationDecoratorBase):
                                                               'status_code',
                                                               status_code)
 
+    @Lazy
+    def form(self):
+        """
+        Process inputs into the form object.
+
+        See also: https://github.com/zopefoundation/pyramid_zope_request/blob/master/src/pyramid_zope_request/__init__.py#L78
+        """
+        # BrowserRequest processes inputs HEAVILY
+        # we'll process only :list because that's only what we use nowadays
+        # and the code in BrowserRequest isn't really reusable
+        params = self.params
+        rv = {}
+        for k in params.keys():
+            v = params.getall(k)
+            if k.endswith(':list'):
+                name = k[:-5]
+            else:
+                v = v[0]
+                name = k
+            rv[name] = v
+
+        return rv
+        
     @non_overridable
     def get(self, key, default=None):
         """

--- a/src/nti/app/pyramid_zope/tests/test_request.py
+++ b/src/nti/app/pyramid_zope/tests/test_request.py
@@ -40,4 +40,3 @@ class TestRequest(SharedConfiguringTestBase):
         zrequest = IBrowserRequest(request)
         assert_that(zrequest.form,
                     {'country': ['Japan', 'Hungary'], 'lastName': 'Doe'})
-        

--- a/src/nti/app/pyramid_zope/tests/test_request.py
+++ b/src/nti/app/pyramid_zope/tests/test_request.py
@@ -29,3 +29,15 @@ class TestRequest(SharedConfiguringTestBase):
         assert_that(zrequest, verifiably_provides(IBrowserRequest))
         # and it's still a valid pyramid request
         assert_that(zrequest, verifiably_provides(IRequest))
+
+    def test_form_parsing(self):
+        environ = {
+            'PATH_INFO': '/',
+            'QUERY_STRING':
+                'lastName=Doe;country:list=Japan;country:list=Hungary',
+        }
+        request = Request(environ)
+        zrequest = IBrowserRequest(request)
+        assert_that(zrequest.form,
+                    {'country': ['Japan', 'Hungary'], 'lastName': 'Doe'})
+        


### PR DESCRIPTION
Locally running tests with tox is showing some unrelated(?) test failures on py3. I'm curios to see how the gh actions look.