### PR TITLE
Add support for Python 3.9.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@
 
 - Add support for I18N.
 
+- Add support for Python 3.9. 3.10 is expected to work once zodbpickle
+  is released with support for 3.10.
+
 0.0.2 (2020-01-02)
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
@@ -95,4 +96,5 @@ setup(
         ] + TESTS_REQUIRE,
     },
     entry_points=entry_points,
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-   py27,py36,py37,py38,pypy,pypy3,coverage,docs
+   py27,py36,py37,py38,py39,pypy,pypy3,coverage,docs
 
 setenv =
    CHAMELEON_CACHE={envbindir}
@@ -13,7 +13,7 @@ commands =
 
 [testenv:coverage]
 basepython =
-    python3.8
+    python3
 commands =
     coverage run -p -m zope.testrunner --test-path=src
     coverage combine
@@ -23,7 +23,7 @@ deps =
 
 [testenv:docs]
 basepython =
-    python3.8
+    python3
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest


### PR DESCRIPTION
3.10 currently can't compile released versions of zodbpickle.